### PR TITLE
refactor: fix the mess introduced by complex lifecycle of ImageBuild in previous refactor

### DIFF
--- a/ec2/subapps/image_builds/README.md
+++ b/ec2/subapps/image_builds/README.md
@@ -1,0 +1,40 @@
+# Documentation on important points.
+
+## Dockerfile updates.
+
+```
+current build states: built, unbuilt
+
+shortcodes for convenience:
+  dcode = dockerfile_code
+  cbuild = current_build
+  
+Cases creating branches:
+  1. dcode is unchanged.
+  2. cbuild is unbuilt.
+  3. new image id is same.
+  4. new image id is different.
+
+Algorithm:
+
+  if dcode is same
+    ret
+
+  if cbuild is unbuilt
+    update cbuild.dcode
+    ret
+
+  Try building new image
+
+  If image ids same
+    update cbuild.dcode
+    ret
+  Else
+    replicate build record
+    assign new image id to it
+    assign dcode to it
+
+    deprecate cbuild
+    update image references to point to new build
+
+```

--- a/ec2/subapps/image_builds/admin_views.py
+++ b/ec2/subapps/image_builds/admin_views.py
@@ -1,11 +1,16 @@
 """Admin-facing views for ImageBuild. Users have no access to this resource —
 it is an infrastructure concern, analogous to AWS AMI build pipelines."""
 
+from multiprocessing import get_context
+
 from django.contrib import messages
 from django.contrib.admin.views.decorators import staff_member_required
 from django.shortcuts import get_object_or_404, redirect, render
 
-from ec2.subapps.image_builds.schemas import BuildResult
+from ec2.subapps.image_builds.schemas import (
+    BuildResult,
+    HandleDockerfileCodeUpdateResult,
+)
 
 from . import services
 from .models import ImageBuild
@@ -34,6 +39,7 @@ def detail_view(request, pk):
     )
 
 
+# TODO: move creation logic to service.
 @staff_member_required
 def create_view(request):
     if request.method == "POST":
@@ -49,39 +55,50 @@ def create_view(request):
 
 
 @staff_member_required
-def update_view(request, pk):
+def update_direct(request, pk):
     build = get_object_or_404(ImageBuild, pk=pk)
     if request.method == "POST":
         tag = request.POST.get("tag", "").strip() or None
-        dockerfile_code = request.POST.get("dockerfile_code", None)
 
         try:
-            result: BuildResult | None = services.update_build(  # type: ignore
-                build,
+            services.handle_direct_updates(  # type: ignore
+                current_build=build,
                 tag=tag,
-                dockerfile_code=dockerfile_code,
             )
         except Exception as exc:  # docker_ops exceptions surface here
             messages.error(request, f"Update failed: {exc}")
             return redirect("ec2_image_builds:detail", pk=build.pk)
 
-        if result is not None and result.new_build is not None:
-            messages.success(
-                request,
-                f"Rebuilt: new build #{result.new_build.pk} active; #{build.pk} deprecated",
-            )
-            return redirect("ec2_image_builds:detail", pk=result.new_build.pk)
-
-        if result is not None and result.is_rebuilt_image_same:
-            messages.success(
-                request,
-                "Only updated code and did not create new build (cause: the resulting image is same).",
-            )
-        else:
-            messages.success(request, "Updated.")
+        messages.success(request, "Update successful.")
 
         return redirect("ec2_image_builds:detail", pk=build.pk)
-    return render(request, "ec2/image_builds/update.html", {"build": build})
+    return render(request, "ec2/image_builds/update_direct.html", {"build": build})
+
+
+@staff_member_required
+def update_dockerfile_code(request, pk):
+    build = get_object_or_404(ImageBuild, pk=pk)
+
+    if request.method == "POST":
+        dockerfile_code = request.POST.get("dockerfile_code", "").strip() or None
+
+        try:
+            result: HandleDockerfileCodeUpdateResult = (
+                services.handle_dockerfile_code_update(  # type: ignore
+                    current_build=build,
+                    dockerfile_code=dockerfile_code,
+                )
+            )
+        except Exception as exc:  # docker_ops exceptions surface here
+            messages.error(request, f"Update failed: {exc}")
+            return redirect("ec2_image_builds:detail", pk=build.pk)
+
+        messages.success(request, result.message)
+
+        return redirect("ec2_image_builds:detail", pk=build.pk)
+    return render(
+        request, "ec2/image_builds/update_dockerfile_code.html", {"build": build}
+    )
 
 
 @staff_member_required
@@ -96,24 +113,13 @@ def build_view(request, pk):
     build = get_object_or_404(ImageBuild, pk=pk)
 
     try:
-        result: BuildResult = services.build(build)
+        result: BuildResult = services.build(current_build=build)
     except Exception as exc:
         messages.error(request, f"Build failed: {exc}")
         return redirect("ec2_image_builds:detail", pk=build.pk)
 
-    if result.new_build is not None:
-        # FIX: change message to also note which build was deprecated.
-        messages.success(
-            request,
-            f"Rebuilt; new build #{result.new_build.pk} is active. #{build.pk} deprecated.",
-        )
-        return redirect("ec2_image_builds:detail", pk=result.new_build.pk)
-    if result.is_rebuilt_image_same:
-        messages.success(
-            request, "Did not create new build. The resulting image is same."
-        )
-    else:
-        messages.success(request, "Built.")
+    messages.success(request, message=result.message)
+
     return redirect("ec2_image_builds:detail", pk=build.pk)
 
 
@@ -123,7 +129,7 @@ def unbuild_view(request, pk):
         return redirect("ec2_image_builds:detail", pk=pk)
     build = get_object_or_404(ImageBuild, pk=pk)
     try:
-        services.unbuild(build)
+        services.unbuild(current_build=build)
         messages.success(request, "Un-built")
     except services.BuildInUseError as exc:
         messages.error(request, str(exc))
@@ -136,7 +142,7 @@ def delete_view(request, pk):
         return redirect("ec2_image_builds:detail", pk=pk)
     build = get_object_or_404(ImageBuild, pk=pk)
     try:
-        services.delete_build(build)
+        services.delete_build(current_build=build)
     except services.BuildInUseError as exc:
         messages.error(request, str(exc))
         return redirect("ec2_image_builds:detail", pk=build.pk)

--- a/ec2/subapps/image_builds/admin_views.py
+++ b/ec2/subapps/image_builds/admin_views.py
@@ -7,6 +7,7 @@ from django.contrib import messages
 from django.contrib.admin.views.decorators import staff_member_required
 from django.shortcuts import get_object_or_404, redirect, render
 
+from ec2.subapps.image_builds.exceptions import CannotOperateOnDeprecatedBuild
 from ec2.subapps.image_builds.schemas import (
     BuildResult,
     HandleDockerfileCodeUpdateResult,
@@ -131,7 +132,7 @@ def unbuild_view(request, pk):
     try:
         services.unbuild(current_build=build)
         messages.success(request, "Un-built")
-    except services.BuildInUseError as exc:
+    except (services.BuildInUseError, services.CannotOperateOnDeprecatedBuild) as exc:
         messages.error(request, str(exc))
     return redirect("ec2_image_builds:detail", pk=build.pk)
 

--- a/ec2/subapps/image_builds/enums.py
+++ b/ec2/subapps/image_builds/enums.py
@@ -1,0 +1,7 @@
+from enum import StrEnum, auto
+
+
+class Status(StrEnum):
+    success = auto()
+    failed = auto()
+    warning = auto()

--- a/ec2/subapps/image_builds/exceptions.py
+++ b/ec2/subapps/image_builds/exceptions.py
@@ -1,0 +1,6 @@
+class BuildInUseError(Exception):
+    pass
+
+
+class CannotOperateOnDeprecatedBuild(Exception):
+    pass

--- a/ec2/subapps/image_builds/models.py
+++ b/ec2/subapps/image_builds/models.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from django.db import models
 
 # TODO: add status field for building
@@ -26,6 +28,18 @@ class ImageBuild(models.Model):
     @property
     def is_built(self) -> bool:
         return self.docker_image_id is not None
+
+    def update(self, field_values_kv: dict[str, Any]):
+        for field, value in field_values_kv.items():
+            if not hasattr(self, field):
+                raise AttributeError(
+                    f"Updating field error: no such attribute '{field}' in {self}.name="
+                )
+            setattr(self, field, value)
+
+        update_fields = list(field_values_kv.keys()) + ["updated_at"]
+
+        self.save(update_fields=update_fields)
 
     def __str__(self) -> str:
         return f"{self.tag} ({'built' if self.is_built else 'unbuilt'})"

--- a/ec2/subapps/image_builds/schemas.py
+++ b/ec2/subapps/image_builds/schemas.py
@@ -1,13 +1,25 @@
 from dataclasses import dataclass
 
+from ec2.subapps.image_builds.enums import Status
+
 from .models import ImageBuild
 
 
 @dataclass
-class RebuildReplaceResult:
-    old_build: ImageBuild
+class GenericServiceFunctionResult:
+    input_build: ImageBuild
     new_build: ImageBuild | None = None
-    is_rebuilt_image_same: bool = False
+    message: str | None = None
+    status: Status = Status.success
 
-class BuildResult(RebuildReplaceResult):
+
+class BuildResult(GenericServiceFunctionResult):
+    pass
+
+
+class HandleDockerfileCodeUpdateResult(GenericServiceFunctionResult):
+    pass
+
+
+class TryReplicationResult(GenericServiceFunctionResult):
     pass

--- a/ec2/subapps/image_builds/services.py
+++ b/ec2/subapps/image_builds/services.py
@@ -1,162 +1,201 @@
-"""Business logic for ImageBuild. Owns mutations of system-managed fields
-(docker_image_id, deprecated) and orchestrates Docker operations through
-docker_ops. Views never call docker_ops directly."""
-
-from copy import copy
+import functools
+from copy import deepcopy
+from typing import Any
 
 from django.db import transaction
 
 import docker_ops
 from docker_ops.utils import text_to_fileobj
-from ec2.subapps.image_builds.schemas import BuildResult, RebuildReplaceResult
+from ec2.subapps.image_builds.enums import Status
+from ec2.subapps.image_builds.schemas import (
+    BuildResult,
+    HandleDockerfileCodeUpdateResult,
+    TryReplicationResult,
+)
 
+from .exceptions import BuildInUseError, CannotOperateOnDeprecatedBuild
 from .models import ImageBuild
 
 
-class BuildInUseError(Exception):
-    """Raised when an un-build/delete is attempted on a build that is
-    referenced by an Image.active_build or any Instance.image_build_in_use."""
+def freeze_operation_on_deprecated(func):
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        current_build = kwargs.get("current_build")
+        if current_build is not None and current_build.deprecated:
+            raise CannotOperateOnDeprecatedBuild(
+                "Cannot carry this operation. Build is deprecated."
+            )
+        result = func(*args, **kwargs)
+
+        return result
+
+    return wrapper
 
 
-# --- low-level: actual Docker invocation --------------------------------
+@freeze_operation_on_deprecated
+def build(*, current_build: ImageBuild) -> BuildResult:
+    result = BuildResult(input_build=current_build)
 
+    if not current_build.is_built:
+        new_id = build_from(current_build)
+        current_build.update({"docker_image_id": new_id})
+        result.message = "Successfully built."
+        return result
 
-def build_from(mib_entity: ImageBuild) -> str:
-    """Pull base image + build Docker image from this entity's Dockerfile.
-    docker_ops.images.build has pull=True hardcoded — registry pull is handled
-    inside the wrapper."""
-    image_id, _logs = docker_ops.images.build(
-        tag=mib_entity.tag,
-        dockerfile_fileobj=text_to_fileobj(mib_entity.dockerfile_code),
+    replication_result: TryReplicationResult = try_replicate_replace_if_image_divergent(  # type: ignore
+        current_build=current_build,  # type: ignore
+        dockerfile_code=current_build.dockerfile_code,  # type: ignore
     )
-    return image_id
 
-
-# --- mutators of system-managed fields ----------------------------------
-
-
-def update_docker_image_id(mib_entity: ImageBuild, new_id: str) -> None:
-    mib_entity.docker_image_id = new_id
-    mib_entity.save(update_fields=["docker_image_id", "updated_at"])
-
-
-# --- replication: create_build_from / rebuild_and_replace ---------------
-
-
-def create_build_record_from(mib_entity: ImageBuild) -> ImageBuild:
-    """Clone the DB record, build a new Docker image, attach its id."""
-    new_mib = copy(mib_entity)
-    new_mib.pk = None
-    new_mib.docker_image_id = None
-    new_mib.deprecated = False
-    new_mib.save()
-    return new_mib
-
-
-def update_image_references(*, old_build: ImageBuild, new_build: ImageBuild) -> None:
-    """Repoint every Image whose active_build == old_build to new_build."""
-    from ec2.subapps.images.models import Image
-
-    Image.objects.filter(active_build=old_build).update(active_build=new_build)
-
-
-@transaction.atomic
-def rebuild_and_replace(old_build: ImageBuild) -> RebuildReplaceResult:
-    """Replication: build a fresh Docker image into a new ImageBuild record,
-    deprecate the old one, and repoint Image.active_build references.
-
-    Existing Instance.image_build_in_use still points at old_build — by design.
-    """
-    result: RebuildReplaceResult = RebuildReplaceResult(old_build=old_build)
-
-    new_image_id = build_from(old_build)
-
-    if new_image_id == old_build.docker_image_id:
-        result.is_rebuilt_image_same = True
+    if replication_result.new_build is not None:
+        result.new_build = replication_result.new_build
+        result.message = replication_result.message
+        result.status = replication_result.status
     else:
-        new_build = create_build_record_from(old_build)
-        new_build.docker_image_id = new_image_id
-        new_build.save()
-
-        old_build.deprecated = True
-        old_build.save(update_fields=["deprecated", "updated_at"])
-        update_image_references(old_build=old_build, new_build=new_build)
-        result.new_build = new_build
+        result.message = "Did not rebuild. Resulting image same."
 
     return result
 
 
-# --- public lifecycle entry points --------------------------------------
+@freeze_operation_on_deprecated
+def handle_direct_updates(*, current_build: ImageBuild, tag: str | None) -> None:
+    updates: dict[str, Any] = {k: v for k, v in {"tag": tag}.items() if v is not None}
+
+    for field, value in updates.items():
+        setattr(current_build, field, value)
+
+    if updates:
+        current_build.save()
 
 
-def build(current_build: ImageBuild) -> BuildResult:
+@freeze_operation_on_deprecated
+def handle_dockerfile_code_update(
+    *, current_build: ImageBuild, dockerfile_code: str
+) -> HandleDockerfileCodeUpdateResult:
+    dockerfile_code_same: bool = current_build.dockerfile_code == dockerfile_code
+
+    result = HandleDockerfileCodeUpdateResult(
+        input_build=current_build,
+    )
+
+    if dockerfile_code_same:
+        result.message = "No update. Dockerfile code is same."
+        return result
+
     if not current_build.is_built:
-        new_id = build_from(current_build)
-        update_docker_image_id(current_build, new_id)
-        return BuildResult(old_build=current_build)
-    return rebuild_and_replace(current_build)  # type: ignore
+        current_build.update({"dockerfile_code": dockerfile_code})
+        result.message = "Update successful."
+        return result
+
+    replication_handler_result: TryReplicationResult = (
+        try_replicate_replace_if_image_divergent(  # type: ignore
+            current_build=current_build,  # type: ignore
+            dockerfile_code=dockerfile_code,  # type: ignore
+        )
+    )
+    replication_handler_message: str | None = replication_handler_result.message
+
+    if replication_handler_result.new_build is not None:
+        result.new_build = replication_handler_result.new_build
+        result.message = replication_handler_result.message
+    else:
+        result.message = concatenate_if_str(
+            replication_handler_message, "Updated dockerfile code."
+        )
+
+    return result
+
+
+@freeze_operation_on_deprecated
+def unbuild(*, current_build: ImageBuild) -> str:
+    """Remove the Docker image without deleting the DB record."""
+    if is_referenced(current_build):
+        raise BuildInUseError("Build is referenced by an Instance or Image")
+    if not current_build.is_built:
+        return "OK"
+    schedule_remove_if_exists_from(current_build)
+    current_build.docker_image_id = None
+    current_build.save(update_fields=["docker_image_id", "updated_at"])
+    return "OK"
+
+
+def delete_build(*, current_build: ImageBuild) -> None:
+    """Delete both the Docker image and the DB record."""
+    if is_referenced(current_build):
+        raise BuildInUseError("Build is referenced by an Instance or Image")
+    schedule_remove_if_exists_from(current_build)
+    current_build.delete()
+
+
+def build_from(build: ImageBuild) -> str:
+    """Pull base image + build Docker image from this entity's Dockerfile.
+    docker_ops.images.build has pull=True hardcoded — registry pull is handled
+    inside the wrapper."""
+    image_id, _logs = docker_ops.images.build(
+        tag=build.tag,
+        dockerfile_fileobj=text_to_fileobj(build.dockerfile_code),
+    )
+    return image_id
 
 
 @transaction.atomic
-def update_build(
-    current_build: ImageBuild,
-    *,
-    tag: str | None = None,
-    dockerfile_code: str | None = None,
-) -> BuildResult | None:
-    """Apply admin updates per the Update lifecycle rule:
+def try_replicate_replace_if_image_divergent(
+    *, current_build: ImageBuild, dockerfile_code: str
+) -> TryReplicationResult:
 
-    - tag change: in-place, no Docker op
-    - dockerfile change OR force_rebuild: triggers rebuild_and_replace
-    """
-    new_build = None
-    tag_changed = tag is not None and tag != current_build.tag
-    dockerfile_code_changed = (
-        dockerfile_code is not None and dockerfile_code != current_build.dockerfile_code
+    result = TryReplicationResult(input_build=current_build)
+
+    image_build_result: tuple[str, Any] = docker_ops.images.build(
+        tag=current_build.tag, dockerfile_fileobj=text_to_fileobj(dockerfile_code)
     )
 
-    if tag_changed:
-        current_build.tag = tag
-        current_build.save()
+    new_image_id: str = image_build_result[0]
 
-    if current_build.is_built and dockerfile_code_changed:
-        new_build = create_build_record_from(current_build)
-        replace_dockerfile_code(new_build, dockerfile_code)
-        new_build.save()
-        result = build(new_build)
-        if new_build.docker_image_id == current_build.docker_image_id:
-            replace_dockerfile_code(current_build, dockerfile_code)
-            current_build.save()
-            new_build.delete()
-            result.is_rebuilt_image_same = True
-        else:
-            current_build.deprecated = True
-            current_build.save()
+    if new_image_id == current_build.docker_image_id:
+        current_build.dockerfile_code = dockerfile_code
+        current_build.save(update_fields=["dockerfile_code"])
+        result.message = "Did not replicate. Resulting image is same."
         return result
-    elif dockerfile_code_changed:
-        replace_dockerfile_code(current_build, dockerfile_code)
-        current_build.save()
-        return BuildResult(old_build=current_build)
 
-    return None
+    else:
+        new_build: ImageBuild = handle_replication(  # type: ignore
+            current_build=current_build,
+            dockerfile_code=dockerfile_code,
+            new_image_id=new_image_id,
+        )
+
+        result.new_build = new_build
+
+        result.message = (
+            "Replication successful: "
+            f"new build #{new_build.pk}. "
+            f" Deprecated: #{current_build.pk}"
+        )
+
+    return result
 
 
-def replace_dockerfile_code(build: ImageBuild, dockerfile_code: str | None):
-    build.dockerfile_code = dockerfile_code
+def concatenate_if_str(v1, v2, delim: str = " "):
+    is_v1_str = isinstance(v1, str)
+    is_v2_str = isinstance(v2, str)
+    if is_v1_str and is_v2_str:
+        return v1 + delim + v2
+    elif is_v1_str:
+        return v1
+    elif is_v2_str:
+        return v2
+    return ""
 
 
-# --- references / un-build / delete -------------------------------------
-
-
-def is_referenced(mib_entity: ImageBuild) -> bool:
+def is_referenced(current_build: ImageBuild) -> bool:
     """True iff any Instance.image_build_in_use or Image.active_build points
     at this build. Blocks un-build and delete."""
     from ec2.subapps.images.models import Image
     from ec2.subapps.instances.models import Instance
 
-    if Image.objects.filter(active_build=mib_entity).exists():
+    if Image.objects.filter(active_build=current_build).exists():
         return True
-    if Instance.objects.filter(image_build_in_use=mib_entity).exists():
+    if Instance.objects.filter(image_build_in_use=current_build).exists():
         return True
     return False
 
@@ -164,10 +203,10 @@ def is_referenced(mib_entity: ImageBuild) -> bool:
 # TODO: implement actual job.
 
 
-def schedule_remove_if_exists_from(mib_entity: ImageBuild) -> None:
+def schedule_remove_if_exists_from(current_build: ImageBuild) -> None:
     """Schedule docker image removal as a background job. Synchronous fallback
     for now — does not block on registry round-trips that already failed."""
-    image_id = mib_entity.docker_image_id
+    image_id = current_build.docker_image_id
     if not image_id:
         return
     try:
@@ -177,27 +216,38 @@ def schedule_remove_if_exists_from(mib_entity: ImageBuild) -> None:
         pass
 
 
-def unbuild(mib_entity: ImageBuild) -> str:
-    """Remove the Docker image without deleting the DB record."""
-    if is_referenced(mib_entity):
-        raise BuildInUseError("Build is referenced by an Instance or Image")
-    if not mib_entity.is_built:
-        return "OK"
-    schedule_remove_if_exists_from(mib_entity)
-    mib_entity.docker_image_id = None
-    mib_entity.save(update_fields=["docker_image_id", "updated_at"])
-    return "OK"
+@transaction.atomic
+def handle_replication(
+    *, current_build: ImageBuild, dockerfile_code: str, new_image_id: str
+) -> ImageBuild:
+    new_build: ImageBuild = create_build_record_from(current_build)
+    new_build.update(
+        {"dockerfile_code": dockerfile_code, "docker_image_id": new_image_id},
+    )
+    current_build.update({"deprecated": True})
+
+    update_image_references(old_build=current_build, new_build=new_build)
+
+    return new_build
 
 
-def delete_build(mib_entity: ImageBuild) -> None:
-    """Delete both the Docker image and the DB record."""
-    if is_referenced(mib_entity):
-        raise BuildInUseError("Build is referenced by an Instance or Image")
-    schedule_remove_if_exists_from(mib_entity)
-    mib_entity.delete()
+def create_build_record_from(build: ImageBuild) -> ImageBuild:
+    """Clone the DB record, build a new Docker image, attach its id."""
+    new_build = deepcopy(build)
+    new_build.pk = None
+    new_build._state.adding = True
+    new_build.docker_image_id = None
+    new_build.deprecated = False
+    new_build.save()
+    return new_build
 
 
-# --- background cleanup -------------------------------------------------
+def update_image_references(*, old_build: ImageBuild, new_build: ImageBuild) -> None:
+    """Repoint every Image whose active_build == old_build to new_build."""
+    from ec2.subapps.images.models import Image
+
+    Image.objects.filter(active_build=old_build).update(active_build=new_build)
+
 
 # TODO: implement actual job.
 

--- a/ec2/subapps/image_builds/urls.py
+++ b/ec2/subapps/image_builds/urls.py
@@ -8,7 +8,12 @@ urlpatterns = [
     path("", admin_views.list_view, name="list"),
     path("create/", admin_views.create_view, name="create"),
     path("<int:pk>/", admin_views.detail_view, name="detail"),
-    path("<int:pk>/update/", admin_views.update_view, name="update"),
+    path("<int:pk>/update-direct/", admin_views.update_direct, name="update_direct"),
+    path(
+        "<int:pk>/update-dockerfile-code/",
+        admin_views.update_dockerfile_code,
+        name="update_dockerfile_code",
+    ),
     path("<int:pk>/build/", admin_views.build_view, name="build"),
     path("<int:pk>/unbuild/", admin_views.unbuild_view, name="unbuild"),
     path("<int:pk>/delete/", admin_views.delete_view, name="delete"),

--- a/templates/ec2/image_builds/detail.html
+++ b/templates/ec2/image_builds/detail.html
@@ -18,7 +18,8 @@
         {% csrf_token %}
         <button class="btn" type="submit">{% if build.is_built %}Rebuild{% else %}Build{% endif %}</button>
     </form>
-    <a class="btn btn-secondary" href="{% url 'ec2_image_builds:update' build.pk %}">Edit</a>
+    <a class="btn btn-secondary" href="{% url 'ec2_image_builds:update_direct' build.pk %}">Edit directs fields</a>
+    <a class="btn btn-secondary" href="{% url 'ec2_image_builds:update_dockerfile_code' build.pk %}">Edit dockerfile code</a>
     {% if build.is_built %}
     <form method="post" action="{% url 'ec2_image_builds:unbuild' build.pk %}">
         {% csrf_token %}

--- a/templates/ec2/image_builds/update_direct.html
+++ b/templates/ec2/image_builds/update_direct.html
@@ -1,0 +1,16 @@
+{% extends "ec2/base.html" %}
+{% block title %}Edit — {{ build.tag }}{% endblock %}
+{% block content %}
+<h1>Edit <span class="tag-pill">{{ build.tag }}</span></h1>
+<p><em>Tag changes are in-place. Dockerfile changes or force_rebuild trigger replication
+(a new ImageBuild record; this one becomes deprecated).</em></p>
+<form method="post" action="{% url 'ec2_image_builds:update_direct' build.pk %}">
+    {% csrf_token %}
+    <div class="field">
+        <label for="tag">Tag</label>
+        <input id="tag" type="text" name="tag" value="{{ build.tag }}" required>
+    </div>
+    <button type="submit" class="btn">Save</button>
+    <a href="{% url 'ec2_image_builds:detail' build.pk %}" class="btn btn-secondary">Cancel</a>
+</form>
+{% endblock %}

--- a/templates/ec2/image_builds/update_dockerfile_code.html
+++ b/templates/ec2/image_builds/update_dockerfile_code.html
@@ -2,14 +2,12 @@
 {% block title %}Edit — {{ build.tag }}{% endblock %}
 {% block content %}
 <h1>Edit <span class="tag-pill">{{ build.tag }}</span></h1>
-<p><em>Tag changes are in-place. Dockerfile changes or force_rebuild trigger replication
-(a new ImageBuild record; this one becomes deprecated).</em></p>
-<form method="post">
+<p><em> Handles change in <code>dockerfile_code</code>. If identical, does not do anything.
+    Otherwise, tries to build new image. If the resulting image is same, the code of current build
+    is updated. Otherwise, triggers new replication which results in replacement and deprecation
+    of current build.</em></p>
+<form method="post" action="{% url 'ec2_image_builds:update_dockerfile_code' build.pk %}">
     {% csrf_token %}
-    <div class="field">
-        <label for="tag">Tag</label>
-        <input id="tag" type="text" name="tag" value="{{ build.tag }}" required>
-    </div>
     <div class="field">
         <label for="dockerfile_code">Dockerfile</label>
         <textarea id="dockerfile_code" name="dockerfile_code" required>{{ build.dockerfile_code }}</textarea>


### PR DESCRIPTION
Closes #13 

- refactor: decompose update on ImageBuild to direct updatable and replication-triggering fields
- feat: add standardization for service results (some are left due to simplicity)
- docs: add document on update cases of dockerfile code & algorithm