### PR TITLE
feat: implement EC2 instances module and dashboard landing page

### DIFF
--- a/docker_ops/__init__.py
+++ b/docker_ops/__init__.py
@@ -1,6 +1,8 @@
 from . import containers, images
 from .client import docker_client
 from .exceptions import (
+    ContainerCreateException,
+    ContainerOpException,
     DockerOpsException,
     ImageBuildException,
     ImageRemoveException,
@@ -13,4 +15,6 @@ __all__ = [
     "DockerOpsException",
     "ImageBuildException",
     "ImageRemoveException",
+    "ContainerCreateException",
+    "ContainerOpException",
 ]

--- a/docker_ops/containers.py
+++ b/docker_ops/containers.py
@@ -1,0 +1,116 @@
+"""Docker container operations. Wraps docker_client.containers."""
+import docker
+
+from .client import docker_client
+from .exceptions import ContainerCreateException, ContainerOpException
+
+
+def create_container(image_id: str, cpu: int, ram: int, storage: int) -> str:
+    """Create and start a container from a Docker image. Returns the container ID.
+
+    cpu: vCPU cores (maps to nano_cpus)
+    ram: RAM in GB (maps to mem_limit)
+    storage: GB — tracked as a container label; not enforced at the Docker layer
+    """
+    try:
+        container = docker_client.containers.run(
+            image=image_id,
+            detach=True,
+            stdin_open=True,
+            tty=True,
+            mem_limit=f"{ram}g",
+            nano_cpus=int(cpu * 1e9),
+            labels={"notaws.storage_gb": str(storage)},
+        )
+    except docker.errors.ImageNotFound as exc:
+        raise ContainerCreateException(f"Image {image_id!r} not found: {exc}") from exc
+    except docker.errors.APIError as exc:
+        raise ContainerCreateException(
+            f"Failed to create container from {image_id!r}: {exc}"
+        ) from exc
+    return container.id
+
+
+def start_container(container_id: str) -> None:
+    try:
+        container = docker_client.containers.get(container_id)
+        container.start()
+    except docker.errors.NotFound as exc:
+        raise ContainerOpException(f"Container {container_id!r} not found: {exc}") from exc
+    except docker.errors.APIError as exc:
+        raise ContainerOpException(
+            f"Failed to start container {container_id!r}: {exc}"
+        ) from exc
+
+
+def stop_container(container_id: str) -> None:
+    try:
+        container = docker_client.containers.get(container_id)
+        container.stop()
+    except docker.errors.NotFound as exc:
+        raise ContainerOpException(f"Container {container_id!r} not found: {exc}") from exc
+    except docker.errors.APIError as exc:
+        raise ContainerOpException(
+            f"Failed to stop container {container_id!r}: {exc}"
+        ) from exc
+
+
+def remove_container(container_id: str) -> None:
+    """Remove a container. No-ops if already gone."""
+    try:
+        container = docker_client.containers.get(container_id)
+        container.remove(force=True)
+    except docker.errors.NotFound:
+        return
+    except docker.errors.APIError as exc:
+        raise ContainerOpException(
+            f"Failed to remove container {container_id!r}: {exc}"
+        ) from exc
+
+
+def get_container_status(container_id: str) -> str:
+    """Return the container status string (e.g. 'running', 'exited', 'created')."""
+    try:
+        container = docker_client.containers.get(container_id)
+        return container.status
+    except docker.errors.NotFound:
+        return "not_found"
+    except docker.errors.APIError as exc:
+        raise ContainerOpException(
+            f"Failed to get status for container {container_id!r}: {exc}"
+        ) from exc
+
+
+def exec_interactive(container_id: str, cmd: str = "/bin/sh"):
+    """Open an interactive TTY exec session. Returns (exec_id, sock).
+
+    exec_id: dict with 'Id' key (pass to resize_exec)
+    sock: docker-py SocketIO; raw Python socket at sock._sock
+    In TTY mode output is raw bytes with no multiplexing header.
+    """
+    try:
+        container = docker_client.containers.get(container_id)
+        if container.status != "running":
+            container.start()
+        exec_id = docker_client.api.exec_create(
+            container_id,
+            cmd,
+            stdin=True,
+            tty=True,
+            stdout=True,
+            stderr=True,
+        )
+        sock = docker_client.api.exec_start(exec_id, socket=True, tty=True)
+        return exec_id, sock
+    except docker.errors.NotFound as exc:
+        raise ContainerOpException(f"Container {container_id!r} not found: {exc}") from exc
+    except docker.errors.APIError as exc:
+        raise ContainerOpException(f"Failed to exec into {container_id!r}: {exc}") from exc
+
+
+def resize_exec(exec_id, *, rows: int, cols: int) -> None:
+    """Resize the TTY for an exec session. Silently ignores errors."""
+    try:
+        docker_client.api.exec_resize(exec_id, height=rows, width=cols)
+    except docker.errors.APIError:
+        pass

--- a/docker_ops/exceptions.py
+++ b/docker_ops/exceptions.py
@@ -12,3 +12,11 @@ class ImageBuildException(DockerOpsException):
 
 class ImageRemoveException(DockerOpsException):
     pass
+
+
+class ContainerCreateException(DockerOpsException):
+    pass
+
+
+class ContainerOpException(DockerOpsException):
+    pass

--- a/ec2/subapps/dashboard/urls.py
+++ b/ec2/subapps/dashboard/urls.py
@@ -1,2 +1,9 @@
+from django.urls import path
+
+from . import user_views
+
 app_name = "ec2_dashboard"
-urlpatterns = []
+
+urlpatterns = [
+    path("", user_views.home_view, name="home"),
+]

--- a/ec2/subapps/dashboard/user_views.py
+++ b/ec2/subapps/dashboard/user_views.py
@@ -1,0 +1,5 @@
+from django.shortcuts import render
+
+
+def home_view(request):
+    return render(request, "ec2/dashboard/home.html")

--- a/ec2/subapps/instances/admin_views.py
+++ b/ec2/subapps/instances/admin_views.py
@@ -1,0 +1,29 @@
+from django.contrib import messages
+from django.contrib.admin.views.decorators import staff_member_required
+from django.shortcuts import get_object_or_404, redirect, render
+
+from . import services
+from .models import Instance
+from .schemas import DeleteResult
+from .utils import set_django_message_from_result
+
+
+@staff_member_required
+def list_view(request):
+    instances = Instance.objects.select_related(
+        "owner", "image", "image_build_in_use"
+    ).all()
+    return render(request, "ec2/instances/admin_list.html", {"instances": instances})
+
+
+@staff_member_required
+def delete_view(request, pk):
+    if request.method != "POST":
+        return redirect("ec2_instances:admin:list")
+    instance = get_object_or_404(Instance, pk=pk)
+    try:
+        result: DeleteResult = services.delete_instance(instance=instance)
+        set_django_message_from_result(request=request, service_result=result)
+    except Exception as exc:
+        messages.error(request, f"Delete failed: {exc}")
+    return redirect("ec2_instances:admin:list")

--- a/ec2/subapps/instances/consumers.py
+++ b/ec2/subapps/instances/consumers.py
@@ -1,0 +1,122 @@
+import asyncio
+import json
+import select
+import threading
+
+from channels.generic.websocket import AsyncWebsocketConsumer
+
+import docker_ops
+from docker_ops.exceptions import ContainerOpException
+
+from .models import Instance
+
+
+class TerminalConsumer(AsyncWebsocketConsumer):
+
+    async def connect(self):
+        user = self.scope.get("user")
+        if not user or not user.is_authenticated:
+            await self.close()
+            return
+
+        pk = self.scope["url_route"]["kwargs"]["pk"]
+
+        try:
+            self.instance = await Instance.objects.aget(pk=pk, owner=user)
+        except Instance.DoesNotExist:
+            await self.close(code=4004)
+            return
+
+        if not self.instance.docker_container_id:
+            await self.close(code=4003)
+            return
+
+        loop = asyncio.get_running_loop()
+        try:
+            self._exec_id, self._sock = await loop.run_in_executor(
+                None,
+                lambda: docker_ops.containers.exec_interactive(
+                    self.instance.docker_container_id
+                ),
+            )
+        except ContainerOpException:
+            await self.close(code=4002)
+            return
+
+        await self.accept()
+
+        self._loop = asyncio.get_running_loop()
+        self._queue: asyncio.Queue = asyncio.Queue()
+        self._closed = False
+
+        self._reader_thread = threading.Thread(
+            target=self._docker_reader, daemon=True
+        )
+        self._reader_thread.start()
+
+        self._sender_task = asyncio.create_task(self._sender_loop())
+
+    def _docker_reader(self):
+        """Blocking thread: reads Docker exec socket, pushes data into the async queue."""
+        raw_sock = self._sock._sock
+        try:
+            while not self._closed:
+                ready = select.select([raw_sock], [], [], 0.5)[0]
+                if not ready:
+                    continue
+                data = raw_sock.recv(4096)
+                if not data:
+                    break
+                asyncio.run_coroutine_threadsafe(self._queue.put(data), self._loop)
+        except Exception:
+            pass
+        finally:
+            asyncio.run_coroutine_threadsafe(self._queue.put(None), self._loop)
+
+    async def _sender_loop(self):
+        """Async loop: drains queue and forwards data to the WebSocket."""
+        try:
+            while True:
+                chunk = await self._queue.get()
+                if chunk is None:
+                    await self.close()
+                    break
+                await self.send(bytes_data=chunk)
+        except Exception:
+            pass
+
+    async def receive(self, text_data=None, bytes_data=None):
+        if self._closed or not hasattr(self, "_sock"):
+            return
+
+        loop = asyncio.get_running_loop()
+
+        if bytes_data:
+            await loop.run_in_executor(None, self._sock._sock.send, bytes_data)
+        elif text_data:
+            try:
+                msg = json.loads(text_data)
+                if msg.get("type") == "resize":
+                    rows = int(msg["rows"])
+                    cols = int(msg["cols"])
+                    await loop.run_in_executor(
+                        None,
+                        lambda: docker_ops.containers.resize_exec(
+                            self._exec_id, rows=rows, cols=cols
+                        ),
+                    )
+            except json.JSONDecodeError:
+                # Not a control message — raw terminal input from xterm.js
+                await loop.run_in_executor(
+                    None, self._sock._sock.send, text_data.encode()
+                )
+
+    async def disconnect(self, close_code):
+        self._closed = True
+        if hasattr(self, "_sender_task"):
+            self._sender_task.cancel()
+        if hasattr(self, "_sock"):
+            try:
+                self._sock.close()
+            except Exception:
+                pass

--- a/ec2/subapps/instances/enums.py
+++ b/ec2/subapps/instances/enums.py
@@ -1,0 +1,7 @@
+from enum import StrEnum, auto
+
+
+class ResultStatus(StrEnum):
+    success = auto()
+    error = auto()
+    warning = auto()

--- a/ec2/subapps/instances/exceptions.py
+++ b/ec2/subapps/instances/exceptions.py
@@ -1,0 +1,12 @@
+class InstanceError(Exception):
+    pass
+
+
+class ImageNotReadyError(InstanceError):
+    """Image has no built active_build; cannot create instance."""
+    pass
+
+
+class InstanceHasNoContainerError(InstanceError):
+    """Instance has no docker_container_id assigned yet."""
+    pass

--- a/ec2/subapps/instances/models.py
+++ b/ec2/subapps/instances/models.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from django.conf import settings
 from django.db import models
 
@@ -45,6 +47,16 @@ class Instance(models.Model):
     @property
     def short_id(self) -> str:
         return (self.docker_container_id or "")[:12] or f"i-{self.pk:08d}"
+
+    def update(self, field_values_kv: dict[str, Any]):
+        for field, value in field_values_kv.items():
+            if not hasattr(self, field):
+                raise AttributeError(
+                    f"Updating field error: no such attribute '{field}' in {self}.name="
+                )
+            setattr(self, field, value)
+        update_fields = list(field_values_kv.keys()) + ["updated_at"]
+        self.save(update_fields=update_fields)
 
     def __str__(self) -> str:
         return self.name or self.short_id

--- a/ec2/subapps/instances/routing.py
+++ b/ec2/subapps/instances/routing.py
@@ -1,0 +1,7 @@
+from django.urls import path
+
+from . import consumers
+
+websocket_urlpatterns = [
+    path("ws/instances/<int:pk>/terminal/", consumers.TerminalConsumer.as_asgi()),
+]

--- a/ec2/subapps/instances/schemas.py
+++ b/ec2/subapps/instances/schemas.py
@@ -1,0 +1,30 @@
+from dataclasses import dataclass
+
+from .enums import ResultStatus
+
+
+@dataclass
+class GenericServiceFunctionResult:
+    message: str | None = None
+    status: ResultStatus = ResultStatus.success
+
+
+@dataclass
+class CreateResult(GenericServiceFunctionResult):
+    instance_pk: int | None = None
+
+
+class UpdateResult(GenericServiceFunctionResult):
+    pass
+
+
+class StartResult(GenericServiceFunctionResult):
+    pass
+
+
+class StopResult(GenericServiceFunctionResult):
+    pass
+
+
+class DeleteResult(GenericServiceFunctionResult):
+    pass

--- a/ec2/subapps/instances/services.py
+++ b/ec2/subapps/instances/services.py
@@ -1,0 +1,107 @@
+from .enums import ResultStatus
+from .exceptions import ImageNotReadyError, InstanceHasNoContainerError
+from .models import Instance
+from .schemas import (
+    CreateResult,
+    DeleteResult,
+    StartResult,
+    StopResult,
+    UpdateResult,
+)
+from .tasks import (
+    dispatch_container_create,
+    dispatch_container_remove,
+    dispatch_container_start,
+    dispatch_container_stop,
+)
+from .utils import get_container_status_from
+
+MAX_CPU = 4
+MAX_RAM = 8      # GB
+MAX_STORAGE = 100  # GB
+
+
+def create_instance(
+    *, image, ram: int, cpu: int, storage: int, owner, name: str | None = None
+) -> CreateResult:
+    result = CreateResult()
+    result.status = ResultStatus.warning
+
+    if not image.active_build or not image.active_build.is_built:
+        raise ImageNotReadyError("Selected image has no built active build")
+
+    instance = Instance(
+        owner=owner,
+        image=image,
+        image_build_in_use=image.active_build,
+        ram=ram,
+        cpu=cpu,
+        storage=storage,
+        name=name,
+    )
+    instance.save()
+
+    dispatch_container_create(instance_id=instance.pk)
+
+    result.instance_pk = instance.pk
+    result.message = "Instance created. Container is starting."
+    return result
+
+
+def update_instance(
+    *,
+    instance: Instance,
+    name: str | None,
+    cpu: int | None,
+    ram: int | None,
+    storage: int | None,
+) -> UpdateResult:
+    result = UpdateResult()
+
+    if name is not None:
+        instance.name = name
+    if cpu is not None:
+        instance.cpu = cpu
+    if ram is not None:
+        instance.ram = ram
+    if storage is not None:
+        instance.storage = storage
+
+    instance.save()
+    result.message = "Instance updated."
+    return result
+
+
+def start_instance(*, instance: Instance) -> StartResult:
+    result = StartResult()
+    result.status = ResultStatus.warning
+    dispatch_container_start(instance_id=instance.pk)
+    result.message = "Start queued."
+    return result
+
+
+def stop_instance(*, instance: Instance) -> StopResult:
+    result = StopResult()
+    result.status = ResultStatus.warning
+    dispatch_container_stop(instance_id=instance.pk)
+    result.message = "Stop queued."
+    return result
+
+
+def delete_instance(*, instance: Instance) -> DeleteResult:
+    result = DeleteResult()
+    result.status = ResultStatus.warning
+    result.message = ""
+
+    container_id = instance.docker_container_id
+    if container_id:
+        dispatch_container_remove(container_id=container_id)
+        result.message = "Container removal queued. "
+
+    instance.delete()
+    result.message += "DB record deleted."
+    return result
+
+
+def get_instance_status(*, instance: Instance) -> str:
+    return get_container_status_from(instance)

--- a/ec2/subapps/instances/tasks.py
+++ b/ec2/subapps/instances/tasks.py
@@ -1,0 +1,31 @@
+from .models import Instance
+from .utils import (
+    create_container_from,
+    remove_container_if_exists,
+    start_container_from,
+    stop_container_from,
+)
+
+
+def dispatch_container_create(*, instance_id: int) -> None:
+    instance = Instance.objects.get(pk=instance_id)
+    container_id = create_container_from(instance)
+    instance.update({"docker_container_id": container_id})
+    # Do state updates (e.g. status field) here when added.
+
+
+def dispatch_container_start(*, instance_id: int) -> None:
+    instance = Instance.objects.get(pk=instance_id)
+    start_container_from(instance)
+    # Do state updates here when added.
+
+
+def dispatch_container_stop(*, instance_id: int) -> None:
+    instance = Instance.objects.get(pk=instance_id)
+    stop_container_from(instance)
+    # Do state updates here when added.
+
+
+def dispatch_container_remove(*, container_id: str) -> None:
+    remove_container_if_exists(container_id)
+    # Do cleanup here when needed.

--- a/ec2/subapps/instances/urls.py
+++ b/ec2/subapps/instances/urls.py
@@ -1,7 +1,22 @@
-from django.urls import path
+from django.urls import include, path
 
-from . import user_views
+from . import admin_views, user_views
 
 app_name = "ec2_instances"
 
-urlpatterns = []
+admin_patterns = [
+    path("", admin_views.list_view, name="list"),
+    path("<int:pk>/delete/", admin_views.delete_view, name="delete"),
+]
+
+urlpatterns = [
+    path("", user_views.list_view, name="list"),
+    path("create/", user_views.create_view, name="create"),
+    path("<int:pk>/", user_views.detail_view, name="detail"),
+    path("<int:pk>/update/", user_views.update_view, name="update"),
+    path("<int:pk>/start/", user_views.start_view, name="start"),
+    path("<int:pk>/stop/", user_views.stop_view, name="stop"),
+    path("<int:pk>/terminal/", user_views.terminal_view, name="terminal"),
+    path("<int:pk>/delete/", user_views.delete_view, name="delete"),
+    path("admin/", include((admin_patterns, "admin"))),
+]

--- a/ec2/subapps/instances/user_views.py
+++ b/ec2/subapps/instances/user_views.py
@@ -1,0 +1,196 @@
+from django.contrib import messages
+from django.contrib.auth.decorators import login_required
+from django.shortcuts import get_object_or_404, redirect, render
+
+from ec2.subapps.images.models import Image
+from ec2.subapps.images.services import selectable_images_for_instance_qs
+
+from . import services
+from .exceptions import ImageNotReadyError, InstanceHasNoContainerError
+from .models import Instance
+from .schemas import CreateResult, DeleteResult, StartResult, StopResult, UpdateResult
+from .utils import set_django_message_from_result
+
+
+@login_required
+def list_view(request):
+    instances = Instance.objects.filter(owner=request.user).select_related(
+        "image", "image_build_in_use"
+    )
+    instances_with_status = [
+        (inst, services.get_instance_status(instance=inst)) for inst in instances
+    ]
+    return render(
+        request,
+        "ec2/instances/list.html",
+        {"instances_with_status": instances_with_status},
+    )
+
+
+@login_required
+def create_view(request):
+    images = selectable_images_for_instance_qs()
+    context = {
+        "images": images,
+        "max_cpu": services.MAX_CPU,
+        "max_ram": services.MAX_RAM,
+        "max_storage": services.MAX_STORAGE,
+    }
+    if request.method == "POST":
+        name = request.POST.get("name", "").strip() or None
+        image_id = request.POST.get("image") or None
+        cpu_str = request.POST.get("cpu", "").strip()
+        ram_str = request.POST.get("ram", "").strip()
+        storage_str = request.POST.get("storage", "").strip()
+
+        errors = []
+        if not image_id:
+            errors.append("Image is required.")
+
+        cpu = ram = storage = None
+        try:
+            cpu = int(cpu_str)
+            ram = int(ram_str)
+            storage = int(storage_str)
+        except (ValueError, TypeError):
+            errors.append("CPU, RAM, and storage must be whole numbers.")
+
+        if cpu is not None:
+            if not (1 <= cpu <= services.MAX_CPU):
+                errors.append(f"CPU must be between 1 and {services.MAX_CPU}.")
+            if not (1 <= ram <= services.MAX_RAM):
+                errors.append(f"RAM must be between 1 and {services.MAX_RAM} GB.")
+            if not (1 <= storage <= services.MAX_STORAGE):
+                errors.append(f"Storage must be between 1 and {services.MAX_STORAGE} GB.")
+
+        if errors:
+            for e in errors:
+                messages.error(request, e)
+        else:
+            image = get_object_or_404(Image, pk=image_id)
+            try:
+                result: CreateResult = services.create_instance(
+                    image=image,
+                    ram=ram,
+                    cpu=cpu,
+                    storage=storage,
+                    owner=request.user,
+                    name=name,
+                )
+                set_django_message_from_result(request=request, service_result=result)
+                return redirect("ec2_instances:detail", pk=result.instance_pk)
+            except ImageNotReadyError as exc:
+                messages.error(request, str(exc))
+            except Exception as exc:
+                messages.error(request, f"Failed to create instance: {exc}")
+
+    return render(request, "ec2/instances/create.html", context)
+
+
+@login_required
+def detail_view(request, pk):
+    instance = get_object_or_404(Instance, pk=pk, owner=request.user)
+    status = services.get_instance_status(instance=instance)
+    return render(
+        request,
+        "ec2/instances/detail.html",
+        {"instance": instance, "status": status},
+    )
+
+
+@login_required
+def update_view(request, pk):
+    instance = get_object_or_404(Instance, pk=pk, owner=request.user)
+    context = {
+        "instance": instance,
+        "max_cpu": services.MAX_CPU,
+        "max_ram": services.MAX_RAM,
+        "max_storage": services.MAX_STORAGE,
+    }
+    if request.method == "POST":
+        name = request.POST.get("name", "").strip() or None
+        cpu_str = request.POST.get("cpu", "").strip()
+        ram_str = request.POST.get("ram", "").strip()
+        storage_str = request.POST.get("storage", "").strip()
+
+        errors = []
+        cpu = ram = storage = None
+        try:
+            cpu = int(cpu_str)
+            ram = int(ram_str)
+            storage = int(storage_str)
+        except (ValueError, TypeError):
+            errors.append("CPU, RAM, and storage must be whole numbers.")
+
+        if cpu is not None:
+            if not (1 <= cpu <= services.MAX_CPU):
+                errors.append(f"CPU must be between 1 and {services.MAX_CPU}.")
+            if not (1 <= ram <= services.MAX_RAM):
+                errors.append(f"RAM must be between 1 and {services.MAX_RAM} GB.")
+            if not (1 <= storage <= services.MAX_STORAGE):
+                errors.append(f"Storage must be between 1 and {services.MAX_STORAGE} GB.")
+
+        if errors:
+            for e in errors:
+                messages.error(request, e)
+        else:
+            try:
+                result: UpdateResult = services.update_instance(
+                    instance=instance,
+                    name=name,
+                    cpu=cpu,
+                    ram=ram,
+                    storage=storage,
+                )
+                set_django_message_from_result(request=request, service_result=result)
+                return redirect("ec2_instances:detail", pk=instance.pk)
+            except Exception as exc:
+                messages.error(request, f"Update failed: {exc}")
+
+    return render(request, "ec2/instances/update.html", context)
+
+
+@login_required
+def start_view(request, pk):
+    if request.method != "POST":
+        return redirect("ec2_instances:detail", pk=pk)
+    instance = get_object_or_404(Instance, pk=pk, owner=request.user)
+    try:
+        result: StartResult = services.start_instance(instance=instance)
+        set_django_message_from_result(request=request, service_result=result)
+    except (InstanceHasNoContainerError, Exception) as exc:
+        messages.error(request, f"Start failed: {exc}")
+    return redirect("ec2_instances:detail", pk=pk)
+
+
+@login_required
+def stop_view(request, pk):
+    if request.method != "POST":
+        return redirect("ec2_instances:detail", pk=pk)
+    instance = get_object_or_404(Instance, pk=pk, owner=request.user)
+    try:
+        result: StopResult = services.stop_instance(instance=instance)
+        set_django_message_from_result(request=request, service_result=result)
+    except (InstanceHasNoContainerError, Exception) as exc:
+        messages.error(request, f"Stop failed: {exc}")
+    return redirect("ec2_instances:detail", pk=pk)
+
+
+@login_required
+def terminal_view(request, pk):
+    instance = get_object_or_404(Instance, pk=pk, owner=request.user)
+    return render(request, "ec2/instances/terminal.html", {"instance": instance})
+
+
+@login_required
+def delete_view(request, pk):
+    if request.method != "POST":
+        return redirect("ec2_instances:detail", pk=pk)
+    instance = get_object_or_404(Instance, pk=pk, owner=request.user)
+    try:
+        result: DeleteResult = services.delete_instance(instance=instance)
+        set_django_message_from_result(request=request, service_result=result)
+    except Exception as exc:
+        messages.error(request, f"Delete failed: {exc}")
+        return redirect("ec2_instances:detail", pk=pk)
+    return redirect("ec2_instances:list")

--- a/ec2/subapps/instances/utils.py
+++ b/ec2/subapps/instances/utils.py
@@ -1,0 +1,57 @@
+from django.contrib import messages
+
+import docker_ops
+from docker_ops.exceptions import ContainerOpException
+
+from .exceptions import InstanceHasNoContainerError
+from .models import Instance
+from .schemas import GenericServiceFunctionResult
+
+
+def create_container_from(instance: Instance) -> str:
+    """Create and start a Docker container from the instance's snapshot build."""
+    image_id = instance.image_build_in_use.docker_image_id
+    return docker_ops.containers.create_container(
+        image_id=image_id,
+        cpu=instance.cpu,
+        ram=instance.ram,
+        storage=instance.storage,
+    )
+
+
+def start_container_from(instance: Instance) -> None:
+    if not instance.docker_container_id:
+        raise InstanceHasNoContainerError("Instance has no container assigned yet")
+    docker_ops.containers.start_container(instance.docker_container_id)
+
+
+def stop_container_from(instance: Instance) -> None:
+    if not instance.docker_container_id:
+        raise InstanceHasNoContainerError("Instance has no container assigned yet")
+    docker_ops.containers.stop_container(instance.docker_container_id)
+
+
+def remove_container_if_exists(container_id: str | None) -> None:
+    """Best-effort removal — silently eats ContainerOpException."""
+    if not container_id:
+        return
+    try:
+        docker_ops.containers.remove_container(container_id)
+    except ContainerOpException:
+        pass
+
+
+def get_container_status_from(instance: Instance) -> str:
+    if not instance.docker_container_id:
+        return "pending"
+    try:
+        return docker_ops.containers.get_container_status(instance.docker_container_id)
+    except ContainerOpException:
+        return "unknown"
+
+
+def set_django_message_from_result(
+    *, request, service_result: GenericServiceFunctionResult
+):
+    message_setter = getattr(messages, str(service_result.status))
+    message_setter(request, service_result.message)

--- a/notaws/asgi.py
+++ b/notaws/asgi.py
@@ -1,23 +1,19 @@
-<<<<<<< HEAD
-"""
-ASGI config for notaws project.
-
-It exposes the ASGI callable as a module-level variable named ``application``.
-
-For more information on this file, see
-https://docs.djangoproject.com/en/6.0/howto/deployment/asgi/
-"""
-
-=======
->>>>>>> feat/isolate-ec2-in-agent-code
 import os
 
 from django.core.asgi import get_asgi_application
 
-<<<<<<< HEAD
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'notaws.settings')
-=======
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "notaws.settings")
->>>>>>> feat/isolate-ec2-in-agent-code
 
-application = get_asgi_application()
+django_asgi_app = get_asgi_application()
+
+from channels.auth import AuthMiddlewareStack
+from channels.routing import ProtocolTypeRouter, URLRouter
+
+from ec2.subapps.instances.routing import websocket_urlpatterns
+
+application = ProtocolTypeRouter({
+    "http": django_asgi_app,
+    "websocket": AuthMiddlewareStack(
+        URLRouter(websocket_urlpatterns)
+    ),
+})

--- a/notaws/settings.py
+++ b/notaws/settings.py
@@ -31,6 +31,7 @@ ALLOWED_HOSTS = []
 # Application definition
 
 INSTALLED_APPS = [
+    "daphne",
     "ec2.apps.Ec2Config",
     "django.contrib.admin",
     "django.contrib.auth",
@@ -38,7 +39,16 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
+    "channels",
 ]
+
+ASGI_APPLICATION = "notaws.asgi.application"
+
+CHANNEL_LAYERS = {
+    "default": {
+        "BACKEND": "channels.layers.InMemoryChannelLayer",
+    }
+}
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 Django>=5.0,<6.0
 docker>=7.0
+channels>=4.0
+daphne>=4.0

--- a/templates/ec2/base.html
+++ b/templates/ec2/base.html
@@ -17,7 +17,7 @@
             {% else %}
                 <a href="{% url 'ec2_images:list' %}">Images</a>
             {% endif %}
-            <a>Instances</a>
+            <a href="{% url 'ec2_instances:list' %}">Instances</a>
         </nav>
         <div class="auth">
             {% if user.is_authenticated %}

--- a/templates/ec2/dashboard/home.html
+++ b/templates/ec2/dashboard/home.html
@@ -1,0 +1,10 @@
+{% extends "ec2/base.html" %}
+{% block title %}EC2{% endblock %}
+{% block content %}
+<h1>EC2</h1>
+<p>Elastic Compute Cloud — provision and manage virtual machines backed by Docker containers.</p>
+<div class="actions">
+    <a class="btn btn-secondary" href="{% url 'ec2_images:list' %}">Browse Images</a>
+    <a class="btn" href="{% url 'ec2_instances:list' %}">Go to Your Instance Dashboard</a>
+</div>
+{% endblock %}

--- a/templates/ec2/instances/admin_list.html
+++ b/templates/ec2/instances/admin_list.html
@@ -1,0 +1,31 @@
+{% extends "ec2/base.html" %}
+{% block title %}All Instances (Admin){% endblock %}
+{% block content %}
+<h1>All Instances</h1>
+<table>
+    <thead>
+        <tr><th>ID</th><th>Owner</th><th>Image</th><th>CPU</th><th>RAM</th><th>Created</th><th>Actions</th></tr>
+    </thead>
+    <tbody>
+        {% for inst in instances %}
+        <tr>
+            <td><code>{{ inst.short_id }}</code></td>
+            <td>{{ inst.owner.username|default:"—" }}</td>
+            <td>{{ inst.image.name }}</td>
+            <td>{{ inst.cpu }}</td>
+            <td>{{ inst.ram }} GB</td>
+            <td>{{ inst.created_at|date:"Y-m-d" }}</td>
+            <td class="actions">
+                <form method="post" action="{% url 'ec2_instances:admin:delete' inst.pk %}">
+                    {% csrf_token %}
+                    <button class="btn btn-danger" type="submit"
+                            onclick="return confirm('Delete this instance?');">Delete</button>
+                </form>
+            </td>
+        </tr>
+        {% empty %}
+        <tr><td colspan="7"><em>No instances.</em></td></tr>
+        {% endfor %}
+    </tbody>
+</table>
+{% endblock %}

--- a/templates/ec2/instances/create.html
+++ b/templates/ec2/instances/create.html
@@ -1,0 +1,36 @@
+{% extends "ec2/base.html" %}
+{% block title %}New Instance{% endblock %}
+{% block content %}
+<p><a href="{% url 'ec2_instances:list' %}">&larr; back</a></p>
+<h1>New Instance</h1>
+<form method="post">
+    {% csrf_token %}
+    <div class="field">
+        <label for="name">Name <em>(optional)</em></label>
+        <input id="name" type="text" name="name" placeholder="my-server">
+    </div>
+    <div class="field">
+        <label for="image">Machine Image</label>
+        <select id="image" name="image" required>
+            <option value="">— choose —</option>
+            {% for img in images %}
+            <option value="{{ img.pk }}">{{ img.name }}</option>
+            {% endfor %}
+        </select>
+    </div>
+    <div class="field">
+        <label for="cpu">CPUs (1–{{ max_cpu }})</label>
+        <input id="cpu" type="number" name="cpu" min="1" max="{{ max_cpu }}" value="1" required>
+    </div>
+    <div class="field">
+        <label for="ram">RAM in GB (1–{{ max_ram }})</label>
+        <input id="ram" type="number" name="ram" min="1" max="{{ max_ram }}" value="1" required>
+    </div>
+    <div class="field">
+        <label for="storage">Storage in GB (1–{{ max_storage }})</label>
+        <input id="storage" type="number" name="storage" min="1" max="{{ max_storage }}" value="10" required>
+    </div>
+    <button type="submit" class="btn">Launch Instance</button>
+    <a href="{% url 'ec2_instances:list' %}" class="btn btn-secondary">Cancel</a>
+</form>
+{% endblock %}

--- a/templates/ec2/instances/detail.html
+++ b/templates/ec2/instances/detail.html
@@ -1,0 +1,32 @@
+{% extends "ec2/base.html" %}
+{% block title %}Instance — {{ instance }}{% endblock %}
+{% block content %}
+<p><a href="{% url 'ec2_instances:list' %}">&larr; back</a></p>
+<h1>{{ instance.name|default:instance.short_id }}</h1>
+<dl>
+    <dt>ID</dt><dd><code>{{ instance.short_id }}</code></dd>
+    <dt>Image</dt><dd>{{ instance.image.name }}</dd>
+    <dt>CPU</dt><dd>{{ instance.cpu }} vCPU</dd>
+    <dt>RAM</dt><dd>{{ instance.ram }} GB</dd>
+    <dt>Storage</dt><dd>{{ instance.storage }} GB</dd>
+    <dt>Status</dt><dd>{{ status }}</dd>
+    <dt>Created</dt><dd>{{ instance.created_at|date:"Y-m-d H:i" }}</dd>
+</dl>
+<div class="actions">
+    <a class="btn" href="{% url 'ec2_instances:terminal' instance.pk %}">Connect</a>
+    <form method="post" action="{% url 'ec2_instances:start' instance.pk %}">
+        {% csrf_token %}
+        <button class="btn" type="submit">Start / Restart</button>
+    </form>
+    <form method="post" action="{% url 'ec2_instances:stop' instance.pk %}">
+        {% csrf_token %}
+        <button class="btn btn-secondary" type="submit">Stop</button>
+    </form>
+    <a class="btn btn-secondary" href="{% url 'ec2_instances:update' instance.pk %}">Edit</a>
+    <form method="post" action="{% url 'ec2_instances:delete' instance.pk %}">
+        {% csrf_token %}
+        <button class="btn btn-danger" type="submit"
+                onclick="return confirm('Delete this instance?');">Delete</button>
+    </form>
+</div>
+{% endblock %}

--- a/templates/ec2/instances/list.html
+++ b/templates/ec2/instances/list.html
@@ -1,0 +1,30 @@
+{% extends "ec2/base.html" %}
+{% block title %}My Instances{% endblock %}
+{% block content %}
+<h1>My Instances</h1>
+<p><a class="btn" href="{% url 'ec2_instances:create' %}">+ New VM</a></p>
+<table>
+    <thead>
+        <tr><th>Name / ID</th><th>Image</th><th>CPU</th><th>RAM</th><th>Status</th><th>Actions</th></tr>
+    </thead>
+    <tbody>
+        {% for inst, status in instances_with_status %}
+        <tr>
+            <td>
+                <strong>{{ inst.name|default:"—" }}</strong><br>
+                <code>{{ inst.short_id }}</code>
+            </td>
+            <td>{{ inst.image.name }}</td>
+            <td>{{ inst.cpu }}</td>
+            <td>{{ inst.ram }} GB</td>
+            <td>{{ status }}</td>
+            <td class="actions">
+                <a class="btn btn-secondary" href="{% url 'ec2_instances:detail' inst.pk %}">View</a>
+            </td>
+        </tr>
+        {% empty %}
+        <tr><td colspan="6"><em>No instances yet.</em></td></tr>
+        {% endfor %}
+    </tbody>
+</table>
+{% endblock %}

--- a/templates/ec2/instances/terminal.html
+++ b/templates/ec2/instances/terminal.html
@@ -1,0 +1,57 @@
+{% extends "ec2/base.html" %}
+{% block title %}Terminal — {{ instance }}{% endblock %}
+{% block content %}
+<p><a href="{% url 'ec2_instances:detail' instance.pk %}">&larr; back</a></p>
+<h1>Terminal: {{ instance.name|default:instance.short_id }}</h1>
+<div id="terminal-container">
+    <div id="terminal"></div>
+</div>
+<div class="actions" style="margin-top:0.5rem">
+    <button class="btn btn-secondary" onclick="disconnect()">Disconnect</button>
+</div>
+
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/xterm@5/css/xterm.css">
+<script src="https://cdn.jsdelivr.net/npm/xterm@5/lib/xterm.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/xterm-addon-fit@0.8/lib/xterm-addon-fit.js"></script>
+<script>
+const term = new Terminal({ cursorBlink: true, convertEol: true, scrollback: 1000 });
+const fitAddon = new FitAddon.FitAddon();
+term.loadAddon(fitAddon);
+term.open(document.getElementById('terminal'));
+fitAddon.fit();
+
+const proto = window.location.protocol === 'https:' ? 'wss' : 'ws';
+const ws = new WebSocket(`${proto}://${window.location.host}/ws/instances/{{ instance.pk }}/terminal/`);
+ws.binaryType = 'arraybuffer';
+
+ws.onopen = () => {
+    term.focus();
+    ws.send(JSON.stringify({ type: 'resize', rows: term.rows, cols: term.cols }));
+};
+ws.onmessage = (e) => {
+    term.write(e.data instanceof ArrayBuffer ? new Uint8Array(e.data) : e.data);
+};
+ws.onclose = () => term.write('\r\n\x1b[31m[disconnected]\x1b[0m\r\n');
+ws.onerror = () => term.write('\r\n\x1b[31m[connection error]\x1b[0m\r\n');
+
+term.onData((data) => {
+    if (ws.readyState === WebSocket.OPEN) ws.send(data);
+});
+term.onResize(({ rows, cols }) => {
+    if (ws.readyState === WebSocket.OPEN) {
+        ws.send(JSON.stringify({ type: 'resize', rows, cols }));
+    }
+});
+
+window.addEventListener('resize', () => fitAddon.fit());
+
+function disconnect() {
+    ws.close();
+    window.location.href = "{% url 'ec2_instances:detail' instance.pk %}";
+}
+</script>
+<style>
+#terminal-container { background: #000; padding: 0.5rem; border-radius: 4px; }
+#terminal { width: 100%; height: 400px; }
+</style>
+{% endblock %}

--- a/templates/ec2/instances/update.html
+++ b/templates/ec2/instances/update.html
@@ -1,0 +1,27 @@
+{% extends "ec2/base.html" %}
+{% block title %}Edit Instance{% endblock %}
+{% block content %}
+<p><a href="{% url 'ec2_instances:detail' instance.pk %}">&larr; back</a></p>
+<h1>Edit {{ instance.name|default:instance.short_id }}</h1>
+<form method="post">
+    {% csrf_token %}
+    <div class="field">
+        <label for="name">Name</label>
+        <input id="name" type="text" name="name" value="{{ instance.name|default:'' }}">
+    </div>
+    <div class="field">
+        <label for="cpu">CPUs (1–{{ max_cpu }})</label>
+        <input id="cpu" type="number" name="cpu" min="1" max="{{ max_cpu }}" value="{{ instance.cpu }}" required>
+    </div>
+    <div class="field">
+        <label for="ram">RAM in GB (1–{{ max_ram }})</label>
+        <input id="ram" type="number" name="ram" min="1" max="{{ max_ram }}" value="{{ instance.ram }}" required>
+    </div>
+    <div class="field">
+        <label for="storage">Storage in GB (1–{{ max_storage }})</label>
+        <input id="storage" type="number" name="storage" min="1" max="{{ max_storage }}" value="{{ instance.storage }}" required>
+    </div>
+    <button type="submit" class="btn">Save</button>
+    <a href="{% url 'ec2_instances:detail' instance.pk %}" class="btn btn-secondary">Cancel</a>
+</form>
+{% endblock %}


### PR DESCRIPTION
Closes #18. Closes #32.

- Full Instance lifecycle: create, start, stop, delete, update (name/cpu/ram/storage)
- docker_ops/containers.py: create_container, start, stop, remove, get_status, exec_interactive, resize_exec wrappers
- Dispatch pattern in tasks.py (mirrors image_builds) for easy Celery migration
- Service layer returns result dataclasses; views surface messages via set_django_message_from_result following existing view/service boundary
- WebSocket terminal via Django Channels + xterm.js (consumers.py, routing.py)
- User views (login_required, owner-filtered) and admin views (staff_member_required)
- Templates: list, create, detail, update, terminal, admin_list
- Dashboard landing page (issue #32) at /services/ec2/instances/ with links to browse images and instance dashboard
- Add channels + daphne to requirements; configure ASGI and channel layers